### PR TITLE
Adds tests, run locally, run remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ milliseconds.
 Pass down the lambda context object as-is from within your handler
 
 ### **REQUIRED** `validator`
-An `async` function that returns either `true` or `false`. Use this function to
-determine completeness ie "is a node available? "did a processing job finish?",
-"is my DB ready to accept connections".
+An `async` function that returns either `truthy` or `falsey`. This function
+determines completeness ie "is a node available? "did a processing job finish?",
+"is my DB ready to accept connections". It is passed the unadulterated payload.
 
 ### **OPTIONAL** `maxRecurse (2)`
 The maximum amount of times to recursively invoke your lambda function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,381 @@
+{
+  "name": "lambda-recurse",
+  "version": "0.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.249.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.249.1.tgz",
+      "integrity": "sha1-KenvNa+xTODpH5kFsz7TVEF7lls=",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.17"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "resolve": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
+      }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
+      }
+    },
+    "tape": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
+      "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.2",
+        "has": "~1.0.3",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.7.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+      "requires": {
+        "lodash": "^4.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/MindPointGroup/lambda-recurse#readme",
   "devDependencies": {
-    "tape": "^4.9.1"
+    "tape": "^4.9.1",
     "aws-sdk": "^2.249.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Recursively execute the current Lambda function until a user-defined condition is met",
   "main": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tape ./test"
   },
   "repository": {
     "type": "git",
@@ -20,5 +20,11 @@
   "bugs": {
     "url": "https://github.com/MindPointGroup/lambda-recurse/issues"
   },
-  "homepage": "https://github.com/MindPointGroup/lambda-recurse#readme"
+  "homepage": "https://github.com/MindPointGroup/lambda-recurse#readme",
+  "devDependencies": {
+    "tape": "^4.9.1"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.249.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
   "homepage": "https://github.com/MindPointGroup/lambda-recurse#readme",
   "devDependencies": {
     "tape": "^4.9.1"
-  },
-  "dependencies": {
     "aws-sdk": "^2.249.1"
   }
 }

--- a/test/aws.js
+++ b/test/aws.js
@@ -1,0 +1,168 @@
+const ss = require('child_process').execSync
+const fs = require('fs')
+
+const AWS = require('aws-sdk')
+
+const config = { region: 'us-east-1' }
+
+if (process.env['PROFILE']) {
+  config.credentials = new AWS.SharedIniFileCredentials({
+    profile: process.env['PROFILE']
+  })
+}
+
+const lambda = new AWS.Lambda(config)
+const sns = new AWS.SNS(config)
+const iam = new AWS.IAM(config)
+
+const api = module.exports = {}
+
+const sr = () => Math.random().toString(16).slice(2)
+
+api.createRole = async () => {
+  const policy = {
+    Version: '2012-10-17',
+    Statement: [{
+      Sid: 'LambdaRole',
+      Effect: 'Allow',
+      Principal: {
+        Service: 'lambda.amazonaws.com'
+      },
+      Action: 'sts:AssumeRole'
+    }]
+  }
+
+  const params = {
+    AssumeRolePolicyDocument: JSON.stringify(policy),
+    Path: '/',
+    RoleName: 'Lambda-' + sr()
+  }
+
+  let data = null
+
+  try {
+    data = await iam.createRole(params).promise()
+  } catch (err) {
+    return { err }
+  }
+
+  return { data }
+}
+
+api.deleteRole = async ({ name }) => {
+  let data = null
+
+  try {
+    data = await iam.deleteRole({ name })
+  } catch (err) {
+    return { err }
+  }
+  return { data }
+}
+
+api.createTopic = async ({ name: Name }) => {
+  try {
+    const data = await sns.createTopic({ Name }).promise()
+    return { data }
+  } catch (err) {
+    return { err }
+  }
+}
+
+api.deleteTopic = async ({ arn: TopicArn }) => {
+  try {
+    const data = await sns.deleteTopic({ TopicArn }).promise()
+    return { data }
+  } catch (err) {
+    return { err }
+  }
+}
+
+api.existsTopic = async ({ arn: TopicArn }) => {
+  try {
+    const data = await sns.getTopicAttributes({ TopicArn }).promise()
+    return { data: !!data.DisplayName }
+  } catch (err) {
+    return { err }
+  }
+}
+
+api.createFunction = async (args) => {
+  const {
+    filename,
+    arn: roleArn
+  } = args
+
+  const target = `/tmp/test.zip`
+
+  try {
+    ss(`zip -j -r ${target} ${filename}`, { cwd: __dirname })
+  } catch (ex) {
+    console.log('unable to zip', String(ex.stdout))
+    process.exit(1)
+  }
+
+  const name = 'test-' + sr()
+
+  const params = {
+    FunctionName: name,
+    Handler: 'index.handler',
+    Timeout: 1,
+    Publish: true,
+    Runtime: 'nodejs8.10',
+    Role: roleArn,
+    Code: {
+      ZipFile: fs.readFileSync(target)
+    }
+  }
+
+  let data = null
+
+  try {
+    data = await lambda.createFunction(params).promise()
+  } catch (err) {
+    return { err }
+  }
+
+  return { data }
+}
+
+api.invokeFunction = async (args) => {
+  const {
+    name: FunctionName,
+    payload: Payload
+  } = args
+
+  const params = {
+    FunctionName,
+    Payload
+  }
+
+  let data = null
+
+  try {
+    data = await lambda.invoke(params).promise()
+  } catch (err) {
+    return { err }
+  }
+
+  return { data }
+}
+
+api.deleteFunction = async (args) => {
+  const { name: FunctionName } = args
+
+  const params = {
+    FunctionName
+  }
+
+  let data = null
+
+  try {
+    data = await lambda.deleteFunction(params).promise()
+  } catch (err) {
+    return { err }
+  }
+
+  return { data }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 process.env.DEBUG = true
 
-// const AWS = require('aws-sdk')
+const aws = require('./aws')
 const recurse = require('..')
 const test = require('tape')
 
@@ -50,7 +50,7 @@ class FakeLambda {
   }
 }
 
-test('failing - max recursion', async t => {
+test('Failing - Run locally (simulate lambda), incur max recursion.', async t => {
   t.plan(4)
 
   const fn = async (event, context) => {
@@ -95,7 +95,7 @@ test('failing - max recursion', async t => {
   t.end()
 })
 
-test('passing - resolved value', async t => {
+test('Passing - Resolved value', async t => {
   let result = null
   const fn = async (event, context) => {
     let subject = false
@@ -130,7 +130,7 @@ test('passing - resolved value', async t => {
   t.end()
 })
 
-test('failing - defaults', async t => {
+test('Failing - Defaults', async t => {
   const fn = async (event, context) => {
     let subject = false
 
@@ -175,5 +175,161 @@ test('failing - validator throws, bubbles up and is caught', async t => {
 
   const lambda = new FakeLambda(fn)
   await fn({}, context)
+  t.end()
+})
+
+let state = {
+  roleArn: null,
+  functionName: null
+}
+
+test('Passing - create Function and a Role able to run it.', async t => {
+  const {
+    err: errCreateRole,
+    data: dataCreateRole
+  } = await aws.createRole()
+
+  t.ok(!errCreateRole, errCreateRole && errCreateRole.message)
+
+  t.comment('wait for the role to become usable')
+  await sleep(3e4)
+
+  state.roleArn = dataCreateRole.Role.Arn
+  t.end()
+})
+
+test('Passing - create and invoke a long running function that eventually creates an sns topic as proof of execution.', async t => {
+  const paramsCreateFunction = {
+    filename: 'test-fn-pass.js',
+    arn: state.roleArn
+  }
+
+  const {
+    err: errCreateFunction,
+    data: dataCreateFunction
+  } = await aws.createFunction(paramsCreateFunction)
+
+  t.ok(!errCreateFunction, errCreateFunction && errCreateFunction.message)
+  t.ok(dataCreateFunction.FunctionName, 'aws provided confirmation of creating the function')
+  t.ok(dataCreateFunction.FunctionName.includes('test-'), 'function was named properly')
+
+  t.comment('wait for the function to become usable')
+  await sleep(3e4)
+
+  const {
+    err: errCreateTopic,
+    data: dataCreateTopic
+  } = await aws.createTopic({ name: dataCreateFunction.FunctionName })
+
+  t.ok(!errCreateTopic, 'an sns topic (with the same name as the lambda function) was created')
+  t.ok(dataCreateTopic.TopicArn, 'the topic created has an arn')
+
+  //
+  // Invoke the function with the arn of the topic. It should get forwarded until the last
+  // invocation of the function and then the lambda function should delete the topic.
+  //
+  const paramsInvokeFunction = {
+    name: dataCreateFunction.FunctionName,
+    payload: JSON.stringify({ topicArn: dataCreateTopic.TopicArn })
+  }
+
+  const {
+    err: errInvokeFunction,
+    data: dataInvokeFunction
+  } = await aws.invokeFunction(paramsInvokeFunction)
+
+  t.ok(!errInvokeFunction, errInvokeFunction && errInvokeFunction.message)
+  t.ok(dataInvokeFunction, 'function was invoked')
+
+  t.comment('waiting for 3e4 (ms)')
+
+  //
+  // all of this should happen in under 30 seconds because the lambda has a timeout of
+  // 0.25 seconds and the maximum level of recursion is set to three.
+  //
+  await sleep(3e4)
+
+  const {
+    err: errTopicExists,
+    data: dataTopicExists
+  } = await aws.existsTopic({ arn: dataCreateTopic.TopicArn })
+
+  t.ok(!errTopicExists, 'Long running function successfully deleted topic')
+  t.ok(!dataTopicExists, 'No topic exists')
+
+  const { err: errDeleteFunction } = await aws.deleteFunction({ name: dataCreateFunction.FunctionName })
+  t.ok(!errDeleteFunction, 'the temporary function was successfully deleted')
+
+  t.end()
+})
+
+test('failing - create and invoke a long running function who\'s failure eventually creates an sns topic as proof of execution.', async t => {
+  const paramsCreateFunction = {
+    filename: 'test-fn-fail.js',
+    arn: state.roleArn
+  }
+
+  const {
+    err: errCreateFunction,
+    data: dataCreateFunction
+  } = await aws.createFunction(paramsCreateFunction)
+
+  t.ok(!errCreateFunction, errCreateFunction && errCreateFunction.message)
+  t.ok(dataCreateFunction.FunctionName, 'aws provided confirmation of creating the function')
+  t.ok(dataCreateFunction.FunctionName.includes('test-'), 'function was named properly')
+
+  t.comment('wait for the function to become usable')
+  await sleep(3e4)
+
+  const {
+    err: errCreateTopic,
+    data: dataCreateTopic
+  } = await aws.createTopic({ name: dataCreateFunction.FunctionName })
+
+  t.ok(!errCreateTopic, 'an sns topic (with the same name as the lambda function) was created')
+  t.ok(dataCreateTopic.TopicArn, 'the topic created has an arn')
+
+  //
+  // Invoke the function with the arn of the topic. It should get forwarded until the last
+  // invocation of the function and then the lambda function should delete the topic.
+  //
+  const paramsInvokeFunction = {
+    name: dataCreateFunction.FunctionName,
+    payload: JSON.stringify({ topicArn: dataCreateTopic.TopicArn })
+  }
+
+  const {
+    err: errInvokeFunction,
+    data: dataInvokeFunction
+  } = await aws.invokeFunction(paramsInvokeFunction)
+
+  t.ok(!errInvokeFunction, errInvokeFunction && errInvokeFunction.message)
+  t.ok(dataInvokeFunction, 'function was invoked')
+
+  t.comment('waiting for 3e4 (ms)')
+
+  //
+  // all of this should happen in under 30 seconds because the lambda has a timeout of
+  // 0.25 seconds and the maximum level of recursion is set to three.
+  //
+  await sleep(3e4)
+
+  const {
+    err: errTopicExists,
+    data: dataTopicExists
+  } = await aws.existsTopic({ arn: dataCreateTopic.TopicArn })
+
+  t.ok(!errTopicExists, 'Long running function successfully deleted topic')
+  t.ok(!dataTopicExists, 'No topic exists')
+
+  const { err: errDeleteFunction } = await aws.deleteFunction({ name: dataCreateFunction.FunctionName })
+  t.ok(!errDeleteFunction, 'the temporary function was successfully deleted')
+
+  t.end()
+})
+
+test('Passing - Delete Function and Role.', async t => {
+  const { err: errDeleteRole } = await aws.deleteRole({ RoleName: state.roleName })
+  t.ok(!errDeleteRole, 'the temporary role was successfully deleted')
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -247,7 +247,7 @@ test('Passing - create and invoke a long running function that eventually create
   // all of this should happen in under 30 seconds because the lambda has a timeout of
   // 0.25 seconds and the maximum level of recursion is set to three.
   //
-  await sleep(6e4)
+  await sleep(6e4 + 3e4)
 
   const {
     err: errTopicExists,
@@ -312,7 +312,7 @@ test('failing - create and invoke a long running function who\'s failure eventua
   // all of this should happen in under 30 seconds because the lambda has a timeout of
   // 0.25 seconds and the maximum level of recursion is set to three.
   //
-  await sleep(6e4)
+  await sleep(6e4 + 3e4)
 
   const {
     err: errTopicExists,

--- a/test/index.js
+++ b/test/index.js
@@ -241,13 +241,13 @@ test('Passing - create and invoke a long running function that eventually create
   t.ok(!errInvokeFunction, errInvokeFunction && errInvokeFunction.message)
   t.ok(dataInvokeFunction, 'function was invoked')
 
-  t.comment('waiting for 3e4 (ms)')
+  t.comment('waiting for 6e4 (ms) for the function to complete')
 
   //
   // all of this should happen in under 30 seconds because the lambda has a timeout of
   // 0.25 seconds and the maximum level of recursion is set to three.
   //
-  await sleep(3e4)
+  await sleep(6e4)
 
   const {
     err: errTopicExists,
@@ -306,13 +306,13 @@ test('failing - create and invoke a long running function who\'s failure eventua
   t.ok(!errInvokeFunction, errInvokeFunction && errInvokeFunction.message)
   t.ok(dataInvokeFunction, 'function was invoked')
 
-  t.comment('waiting for 3e4 (ms)')
+  t.comment('waiting for 6e4 (ms) for the function to complete')
 
   //
   // all of this should happen in under 30 seconds because the lambda has a timeout of
   // 0.25 seconds and the maximum level of recursion is set to three.
   //
-  await sleep(3e4)
+  await sleep(6e4)
 
   const {
     err: errTopicExists,

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,134 @@
+process.env.DEBUG = true
+
+// const AWS = require('aws-sdk')
+const recurse = require('..')
+const test = require('tape')
+
+class Context {
+  constructor () {
+    this.ms = 2000
+  }
+
+  getRemainingTimeInMillis () {
+    return (this.ms = this.ms / 2)
+  }
+
+  reset () {
+    this.ms = 3e4
+  }
+}
+
+const context = new Context()
+
+class FakeLambda {
+  constructor (fn) {
+    this.fn = fn
+  }
+
+  invoke (args) {
+    const {
+      InvocationType,
+      FunctionName,
+      Payload
+    } = args
+
+    if (!InvocationType) throw new Error('InvocationType required')
+    if (!FunctionName) throw new Error('FunctionName required')
+    if (!Payload) throw new Error('Payload required')
+
+    context.reset()
+
+    const fn = this.fn
+
+    function promise () {
+      return new Promise(resolve => setTimeout(async () => {
+        const params = [JSON.parse(Payload), context]
+        const res = await fn(...params)
+        resolve({ Payload: JSON.stringify(res) })
+      }, 1))
+    }
+
+    return { promise }
+  }
+}
+
+test('max recursion', async t => {
+  const fn = async (event, context) => {
+    let subject = false
+
+    setTimeout(() => {
+      subject = { success: true }
+    }, 5000)
+
+    const args = {
+      context,
+      payload: event,
+      validator: () => subject,
+      interval: 100,
+      maxRecurse: 3,
+      maxTimeLeft: 100
+    }
+
+    try {
+      const data = await recurse(lambda, args)
+
+      //
+      // If the data has already been processed by a lambda, it will
+      // have a statusCode, in which case we can return it without
+      // wrapping it.
+      //
+      return data.statusCode ? data : {
+        statusCode: 200,
+        body: data
+      }
+    } catch (err) {
+      return {
+        statusCode: 500,
+        body: err.message
+      }
+    }
+  }
+
+  const lambda = new FakeLambda(fn)
+  const expected = { statusCode: 500, body: 'Max recursion' }
+  t.deepEqual(await fn({}, context), expected)
+  t.end()
+})
+
+test('resolved value', async t => {
+  const fn = async (event, context) => {
+    let subject = false
+
+    setTimeout(() => {
+      subject = { success: true }
+    }, 5000)
+
+    const args = {
+      context,
+      payload: event,
+      validator: () => subject,
+      interval: 1000,
+      maxRecurse: 3,
+      maxTimeLeft: 100
+    }
+
+    try {
+      const data = await recurse(lambda, args)
+
+      return data.statusCode ? data : {
+        statusCode: 200,
+        body: data
+      }
+    } catch (err) {
+      return {
+        statusCode: 500,
+        body: err.message
+      }
+    }
+  }
+
+  const lambda = new FakeLambda(fn)
+  const expected = { statusCode: 200, body: { success: true } }
+  t.deepEqual(await fn({}, context), expected)
+  t.end()
+})

--- a/test/test-fn-fail.js
+++ b/test/test-fn-fail.js
@@ -9,7 +9,10 @@ const sleep = t => new Promise(resolve => setTimeout(resolve, t))
 
 module.exports = async (event, context) => {
   const validator = async p => {
-    if (event._ && event._.recurseAttempt > 2) {
+    if (event._ && event._.recurseAttempt > 4) {
+      //
+      // This will never be reached...
+      //
       return { success: true }
     }
 
@@ -17,14 +20,14 @@ module.exports = async (event, context) => {
     // Sleep longer than the interval
     // in order to force an invocation.
     //
-    await sleep(2000)
+    await sleep(3e4)
   }
 
   const args = {
     context,
     payload: event,
     validator,
-    interval: 1000,
+    interval: 3e4,
     maxRecurse: 3,
     maxTimeLeft: 100
   }
@@ -32,6 +35,10 @@ module.exports = async (event, context) => {
   try {
     await recurse(lambda, args)
   } catch (err) {
+    //
+    // The expected outcome is that the meta-data in the forwarded payload
+    // shows the total recursion attemps to exceed the maximum allowed.
+    //
     if (err.message === 'Max recursion') {
       await sns.deleteTopic({ TopicArn: event.topicArn }).promise()
     }

--- a/test/test-fn-fail.js
+++ b/test/test-fn-fail.js
@@ -1,0 +1,39 @@
+const recurse = require('..')
+const AWS = require('aws-sdk')
+
+const config = { region: 'us-east-1' }
+const lambda = new AWS.Lambda(config)
+const sns = new AWS.SNS(config)
+
+const sleep = t => new Promise(resolve => setTimeout(resolve, t))
+
+module.exports = async (event, context) => {
+  const validator = async p => {
+    if (event._ && event._.recurseAttempt > 2) {
+      return { success: true }
+    }
+
+    //
+    // Sleep longer than the interval
+    // in order to force an invocation.
+    //
+    await sleep(2000)
+  }
+
+  const args = {
+    context,
+    payload: event,
+    validator,
+    interval: 1000,
+    maxRecurse: 3,
+    maxTimeLeft: 100
+  }
+
+  try {
+    await recurse(lambda, args)
+  } catch (err) {
+    if (err.message === 'Max recursion') {
+      await sns.deleteTopic({ TopicArn: event.topicArn }).promise()
+    }
+  }
+}

--- a/test/test-fn-pass.js
+++ b/test/test-fn-pass.js
@@ -17,14 +17,14 @@ module.exports = async (event, context) => {
     // Sleep longer than the interval
     // in order to force an invocation.
     //
-    await sleep(2000)
+    await sleep(3e4)
   }
 
   const args = {
     context,
     payload: event,
     validator,
-    interval: 1000,
+    interval: 3e4,
     maxRecurse: 3,
     maxTimeLeft: 100
   }

--- a/test/test-fn-pass.js
+++ b/test/test-fn-pass.js
@@ -1,0 +1,40 @@
+const recurse = require('..')
+const AWS = require('aws-sdk')
+
+const config = { region: 'us-east-1' }
+const lambda = new AWS.Lambda(config)
+const sns = new AWS.SNS(config)
+
+const sleep = t => new Promise(resolve => setTimeout(resolve, t))
+
+module.exports = async (event, context) => {
+  const validator = async p => {
+    if (event._ && event._.recurseAttempt > 2) {
+      return { success: true }
+    }
+
+    //
+    // Sleep longer than the interval
+    // in order to force an invocation.
+    //
+    await sleep(2000)
+  }
+
+  const args = {
+    context,
+    payload: event,
+    validator,
+    interval: 1000,
+    maxRecurse: 3,
+    maxTimeLeft: 100
+  }
+
+  try {
+    const data = await recurse(lambda, args)
+
+    if (data && data.success) {
+      await sns.deleteTopic({ TopicArn: event.topicArn }).promise()
+    }
+  } catch (err) {
+  }
+}


### PR DESCRIPTION
As per the road map/wish list, this PR adds tests for running locally *and* running remotely, it also shuffles the code around a bit to make it more `async/await`-ish.

The idea for testing locally is to emulate Lambda's invocation. The fake Lambda api instance contains a real Lambda function that will be recursed. On each iteration, the payload is forwarded to the next and a global state (`Tape#plan(n)`) is the expected proof for failure and success cases.

The idea for testing remotely is to 1. Create an SNS topic (to be deleted by the Lambda function). 2. Create a role to run a Lambda function. 3. Create a Lambda function (with a 1 minute timeout), deploy and invoke it. 4. Wait longer than 1 minute 5. The deleted SNS topic is the expected proof for failure and success cases.